### PR TITLE
brender/glrend: remove free->check->free loop

### DIFF
--- a/brender-crocde-1.4.0-dev/glrend/devpixmp.c
+++ b/brender-crocde-1.4.0-dev/glrend/devpixmp.c
@@ -413,8 +413,6 @@ void BR_CMETHOD_DECL(br_device_pixelmap_gl, free)(br_object *_self)
 
     ObjectContainerRemove(self->output_facility, (br_object *)self);
 
-    OutputFacilityGLOnPixelmapFree(self->output_facility, self);
-
     BrResFreeNoCallback(self);
 }
 

--- a/brender-crocde-1.4.0-dev/glrend/drv_ip.h
+++ b/brender-crocde-1.4.0-dev/glrend/drv_ip.h
@@ -59,8 +59,6 @@ br_renderer_facility *RendererFacilityGLInit(br_device *dev);
  */
 br_output_facility *OutputFacilityGLCreateTemporary(br_device *dev, br_token_value *tv);
 
-void OutputFacilityGLOnPixelmapFree(br_output_facility *outfcty, br_device_pixelmap *pixmp);
-
 br_error OutputFacilityGLEnumerate(br_device *device);
 
 /*

--- a/brender-crocde-1.4.0-dev/glrend/outfcty.c
+++ b/brender-crocde-1.4.0-dev/glrend/outfcty.c
@@ -163,26 +163,6 @@ br_output_facility *OutputFacilityGLCreateTemporary(br_device *dev, br_token_val
     return OutputFacilityGLCreateMode(dev, pmt, width, height, -1, 1);
 }
 
-void OutputFacilityGLOnPixelmapFree(br_output_facility *outfcty, br_device_pixelmap *pixmp)
-{
-    br_device_pixelmap *pm = NULL;
-
-    (void)pixmp;
-
-    if(!outfcty->temporary)
-        return;
-
-    /* Find a device pixelmap. If this fails, we don't care. */
-    (void)ObjectContainerFind(outfcty, (struct br_object **)&pm, BRT_DEVICE_PIXELMAP, NULL, NULL);
-
-    if(pm != NULL)
-        return;
-
-    /* No pixelmaps left, destroy */
-    ObjectFree(outfcty);
-}
-
-
 br_error OutputFacilityGLEnumerate(br_device *device)
 {
     int numMonitors = SDL_GetNumVideoDisplays();


### PR DESCRIPTION
Presumably a leftover from an earlier version, when a device pixelmap is freed, it removes itself from its output facility. When all devpixmps are destroyed, the outfcty is freed. This breaks when the outfcty is freed first, so remove it.

Closes #3 