### PR TITLE
Overhaul install locations

### DIFF
--- a/cmake/brender.pc.in
+++ b/cmake/brender.pc.in
@@ -1,0 +1,9 @@
+libdir="@CMAKE_INSTALL_FULL_LIBDIR@/brender"
+includedir="@CMAKE_INSTALL_FULL_INCLUDEDIR@/brender"
+
+Name: @PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Cflags: -I"${includedir}" -I"${includedir}/glrend" -I"${includedir}/sdl2dev"
+Libs: -L"${libdir}" -lglrend -lsdl2dev -lbrender

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -2,47 +2,59 @@
 # Add all core targets to the "Core" export, and
 # configure their "include" and "ddi" filesets to be copied.
 ##
+
+include(GNUInstallDirs)
+
+install(TARGETS
+        brender brender-ddi
+        EXPORT Core
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/brender
+        )
+
 install(TARGETS
         brender-inc brender-inc-ddi
         inc fmt fw host math nulldev pixelmap std v1db
-        brender brender-ddi
         EXPORT Core
-        FILE_SET include DESTINATION include
-        FILE_SET ddi DESTINATION ddi
+        FILE_SET include DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/brender
+        FILE_SET ddi DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/brender/ddi
         )
 
 if (BRENDER_BUILD_DRIVERS)
     if (TARGET glrend)
         install(TARGETS glrend-headers
                 EXPORT Core
-                FILE_SET include DESTINATION drivers/glrend/include
+                FILE_SET include DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/brender/glrend
                 )
 
         install(TARGETS glrend
                 EXPORT Core
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/brender
                 )
     endif()
 
     if (TARGET sdl2dev)
         install(TARGETS sdl2dev-headers
                 EXPORT Core
-                FILE_SET include DESTINATION drivers/sdl2dev/include
+                FILE_SET include DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/brender/sdl2dev
                 )
 
         install(TARGETS sdl2dev
                 EXPORT Core
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/brender
                 )
     endif()
 
     if (TARGET softrend)
         install(TARGETS softrend
                 EXPORT Core
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/brender
                 )
     endif()
 
     if (TARGET pentprim)
         install(TARGETS pentprim
                 EXPORT Core
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/brender
                 )
     endif()
 
@@ -76,3 +88,7 @@ install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/BRenderConfigVersion.cmake
         DESTINATION lib/cmake/brender
         )
+
+# pkg-config
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/brender.pc.in ${CMAKE_CURRENT_BINARY_DIR}/brender.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/brender.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,6 +3,10 @@
 # Added to by each target.
 ##
 add_library(brender-inc INTERFACE)
+target_include_directories(brender-inc INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include/brender>
+        )
 
 ##
 # BRender DDI - superset of the public includes.

--- a/drivers/glrend/CMakeLists.txt
+++ b/drivers/glrend/CMakeLists.txt
@@ -115,7 +115,7 @@ target_sources(glrend-headers INTERFACE
 
 target_include_directories(glrend-headers INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:drivers/glrend/include>
+        $<INSTALL_INTERFACE:include/brender/glrend>
         )
 
 set_target_properties(glrend-headers PROPERTIES

--- a/drivers/sdl2dev/CMakeLists.txt
+++ b/drivers/sdl2dev/CMakeLists.txt
@@ -14,7 +14,7 @@ target_sources(sdl2dev-headers INTERFACE
         )
 target_include_directories(sdl2dev-headers INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:drivers/sdl2dev/include>
+        $<INSTALL_INTERFACE:include/brender/sdl2dev>
         )
 
 set_target_properties(sdl2dev-headers PROPERTIES

--- a/tools/3ds2br/CMakeLists.txt
+++ b/tools/3ds2br/CMakeLists.txt
@@ -3,4 +3,6 @@ project(3ds2br)
 add_executable(3ds2br ./3ds2br.c)
 target_link_libraries(3ds2br PRIVATE BRender::Core)
 
-install(TARGETS 3ds2br)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS 3ds2br DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/tools/dquery/CMakeLists.txt
+++ b/tools/dquery/CMakeLists.txt
@@ -3,4 +3,6 @@ project(dquery)
 add_executable(dquery ./dquery.c)
 target_link_libraries(dquery PRIVATE BRender::Core BRender::DDI)
 
-install(TARGETS dquery)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS dquery DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/tools/matconv/CMakeLists.txt
+++ b/tools/matconv/CMakeLists.txt
@@ -3,4 +3,6 @@ project(matconv)
 add_executable(matconv matconv.c)
 target_link_libraries(matconv PRIVATE BRender::Core)
 
-install(TARGETS matconv)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS matconv DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/tools/mkblend/CMakeLists.txt
+++ b/tools/mkblend/CMakeLists.txt
@@ -3,4 +3,6 @@ project(mkblend)
 add_executable(mkblend ./mkblend.c)
 target_link_libraries(mkblend PRIVATE BRender::Core)
 
-install(TARGETS mkblend)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS mkblend DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/tools/mkfog/CMakeLists.txt
+++ b/tools/mkfog/CMakeLists.txt
@@ -3,4 +3,6 @@ project(mkfog)
 add_executable(mkfog ./mkfog.c)
 target_link_libraries(mkfog PRIVATE BRender::Core)
 
-install(TARGETS mkfog)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS mkfog DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/tools/mkranges/CMakeLists.txt
+++ b/tools/mkranges/CMakeLists.txt
@@ -3,4 +3,6 @@ project(mkranges)
 add_executable(mkranges ./mkranges.c)
 target_link_libraries(mkranges PRIVATE BRender::Core)
 
-install(TARGETS mkranges)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS mkranges DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/tools/mkshades/CMakeLists.txt
+++ b/tools/mkshades/CMakeLists.txt
@@ -3,4 +3,6 @@ project(mkshades)
 add_executable(mkshades ./mkshades.c)
 target_link_libraries(mkshades PRIVATE BRender::Core)
 
-install(TARGETS mkshades)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS mkshades DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/tools/paljoin/CMakeLists.txt
+++ b/tools/paljoin/CMakeLists.txt
@@ -3,4 +3,6 @@ project(paljoin)
 add_executable(paljoin ./paljoin.c)
 target_link_libraries(paljoin PRIVATE BRender::Core)
 
-install(TARGETS paljoin)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS paljoin DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/tools/texconv/CMakeLists.txt
+++ b/tools/texconv/CMakeLists.txt
@@ -29,4 +29,6 @@ add_executable(texconv
 target_compile_definitions(texconv PRIVATE -DDISABLE_VIEWING)
 target_link_libraries(texconv PRIVATE BRender::Core)
 
-install(TARGETS texconv)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS texconv DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/tools/texview/CMakeLists.txt
+++ b/tools/texview/CMakeLists.txt
@@ -7,4 +7,6 @@ add_executable(texview
 target_compile_definitions(texview PRIVATE -DSDL_MAIN_HANDLED)
 target_link_libraries(texview PRIVATE BRender::Core BRender::Drivers::SDL2Dev)
 
-install(TARGETS texview)
+if (NOT BRENDER_DISABLE_INSTALL)
+	install(TARGETS texview DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()


### PR DESCRIPTION
I want to use BRender in a project of mine, but I was dissatisfied with the default install locations for the libraries, headers and tool binaries. I've updated it to reflect this sort of structure (UNIX directories shown):

Libraries go to:
`/usr/local/brender/lib`

Headers go to:
`/usr/local/brender/include`

Binaries go to:
`/usr/local/brender/bin`

DDI and the device drivers go to subfolders of the above.

I also added a pkg-config script, so you can use BRender with pkg-config rather than CMake.